### PR TITLE
Fix Slack request verification

### DIFF
--- a/api/events.ts
+++ b/api/events.ts
@@ -17,7 +17,14 @@ export async function POST(request: Request) {
     return new Response(payload.challenge, { status: 200 });
   }
 
-  await verifyRequest({ requestType, request, rawBody });
+  const verificationResponse = await verifyRequest({
+    requestType,
+    request,
+    rawBody,
+  });
+  if (verificationResponse) {
+    return verificationResponse;
+  }
 
   try {
     const botUserId = await getBotId();


### PR DESCRIPTION
## Summary
- handle the return value from `verifyRequest` so invalid requests are rejected

## Testing
- `npx tsc --noEmit` *(fails: cannot find module '@slack/web-api', etc.)*